### PR TITLE
fix myth test case

### DIFF
--- a/test/expects/myth.js
+++ b/test/expects/myth.js
@@ -1,1 +1,1 @@
-require("insert-css")("a{-webkit-transition:color .2s;transition:color .2s;color:#847AD1}pre{padding:10px}");
+require("insert-css")("a{color:#847AD1}pre{padding:10px;margin:20px}");

--- a/test/fixtures/myth.vue
+++ b/test/fixtures/myth.vue
@@ -5,11 +5,11 @@
 }
 
 a {
-  transition: color .2s;
   color: var(--purple);
 }
 
 pre {
   padding: var(--large);
+  margin: calc(var(--large) * 2);
 }
 </style>


### PR DESCRIPTION
Autoprefixer is not stable since old browsers are dying, less
and less vendor prefix is needed.
Remove it from test case, add another myth feature: math