### PR TITLE
Feature request for html minify option

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ exports.compile = function (content, filePath, cb) {
   // only 1 template tag is allowed, while styles and
   // scripts are concatenated.
   var template
+  var htmlMinifyOption
   var script = ''
   var style = ''
   var output = ''
@@ -43,6 +44,8 @@ exports.compile = function (content, filePath, cb) {
     switch (node.nodeName) {
       case 'template':
         template = checkSrc(node, filePath) || serializeTemplate(node)
+        htmlMinifyOption = checkMinify(node)
+        htmlMinifyOption = htmlMinifyOption ? JSON.parse(htmlMinifyOption) : {}
         var lang = checkLang(node)
         if (templateLangs.indexOf(lang) < 0) {
           break
@@ -100,7 +103,7 @@ exports.compile = function (content, filePath, cb) {
 
     // template
     if (template) {
-      template = htmlMinifier.minify(template)
+      template = htmlMinifier.minify(template, htmlMinifyOption)
         .replace(/"/g, '\\"')
         .replace(/\n/g, "\\n")
       output += 'var __vue_template__ = "' + template + '";\n'
@@ -149,6 +152,18 @@ function checkSrc (node, filePath) {
             )
           }
         }
+      }
+    }
+  }
+}
+
+function checkMinify (node) {
+  if (node.attrs) {
+    var i = node.attrs.length
+    while (i--) {
+      var attr = node.attrs[i]
+      if (attr.name === 'minify') {
+        return attr.value
       }
     }
   }

--- a/index.js
+++ b/index.js
@@ -44,8 +44,7 @@ exports.compile = function (content, filePath, cb) {
     switch (node.nodeName) {
       case 'template':
         template = checkSrc(node, filePath) || serializeTemplate(node)
-        htmlMinifyOption = checkMinify(node)
-        htmlMinifyOption = htmlMinifyOption ? JSON.parse(htmlMinifyOption) : {}
+        htmlMinifyOption = JSON.parse(checkMinify(node) || '{}')
         var lang = checkLang(node)
         if (templateLangs.indexOf(lang) < 0) {
           break


### PR DESCRIPTION
@yyx990803 Thank you for your great vue compiler!
I love .vue file system, it is very useful!
I have a request for additional feature about html minify.

Now, the compiler use html-minifier without minify option.
Therefore, when I used normal html template, builded html inside javascript is not minified.

From this PR and add `minify` attribute to template tag like
`<template minify='{"collapseWhitespace":true, "removeComments":true}'>`
makes html minified.
If the attribution name `minify` is bad name, please tell me better attribution name.
(`html-minify` or `html-minify-option` is better?)

Sorry, about my bad English.