### PR TITLE
replace \ with \\ in minified style/template

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,6 +101,7 @@ exports.compile = function (content, filePath, cb) {
     // style
     if (style) {
       style = cssMinifier.minify(style)
+        .replace(/\\/g, '\\\\')
         .replace(/"/g, '\\"')
         .replace(/\n/g, "\\n")
       output += 'require("insert-css")("' + style + '");\n'
@@ -109,6 +110,7 @@ exports.compile = function (content, filePath, cb) {
     // template
     if (template) {
       template = htmlMinifier.minify(template)
+        .replace(/\\/g, '\\\\')
         .replace(/"/g, '\\"')
         .replace(/\n/g, "\\n")
       output += 'var __vue_template__ = "' + template + '";\n'


### PR DESCRIPTION
ensure that code like "content:'\e940';" can be inserted into build.js properly.
