### PR TITLE
fixed issue with errors not outputting

### DIFF
--- a/compilers/sass.js
+++ b/compilers/sass.js
@@ -22,7 +22,10 @@ module.exports = function (raw, cb) {
   },
   // callback for node-sass > 3.0.0
   function (err, res) {
-    if (err) return err
-    cb(null, res.css.toString())
+    if (err) {
+      cb(err)
+    } else {
+      cb(null, res.css.toString())
+    }
   })
 }


### PR DESCRIPTION
Sass >= 3.0 now outputs the error instead of just leaving you hanging.