### PR TITLE
fix: Fill up missing source file path in postcss-clean

### DIFF
--- a/src/postcss-clean.ts
+++ b/src/postcss-clean.ts
@@ -6,7 +6,7 @@ export default postcss.plugin('clean', options => {
 
   return (css: any, res: any) => {
     const output = clean.minify(css.toString())
-
-    res.root = postcss.parse(output.styles)
+    const from = css.source && css.source.input && css.source.input.file
+    res.root = postcss.parse(output.styles, {from})
   }
 })


### PR DESCRIPTION
The postcss-clean missed "from" (source file path) in the result root AST node.
That causes issue on other postcss plugin which needs the information postcss/postcss-url#132.