### PR TITLE
move head declaration

### DIFF
--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -88,7 +88,6 @@ export function assembleFromSource(
 
   // language=JavaScript
   const inlineCreateInjector = `function __vue_create_injector__() {
-    const head = document.head || document.getElementsByTagName('head')[0]
     const styles = __vue_create_injector__.styles || (__vue_create_injector__.styles = {})
     const isOldIE =
       typeof navigator !== 'undefined' &&
@@ -122,6 +121,7 @@ export function assembleFromSource(
         }
 
         if (!style.element) {
+          const head = document.head || document.getElementsByTagName('head')[0]
           const el = style.element = document.createElement('style')
           el.type = 'text/css'
 


### PR DESCRIPTION
This is to avoid the `document is not defined` when loading a SSR ready SFC in Nuxt.