### PR TITLE
fix: set correct clean-css import

### DIFF
--- a/src/postcss-clean.ts
+++ b/src/postcss-clean.ts
@@ -1,5 +1,7 @@
 import * as postcss from 'postcss'
-import CleanCSS from 'clean-css'
+// ESM import of clean-css breaks test/runtime check this fix for reference:
+// https://github.com/vuejs/vue-component-compiler/pull/103#issuecomment-632676899
+const CleanCSS = require('clean-css')
 
 export default postcss.plugin('clean', (options: any) => {
   const clean = new CleanCSS({ compatibility: 'ie9', ...options })


### PR DESCRIPTION
Incorrect import cause an error during compilation:
```
[!] (VuePlugin plugin) TypeError: clean_css_1.default is not a constructor
```

I tried to use `import * as CleanCSS from 'clean-css'` but then it was not working correctly in unit tests. 

