### PR TITLE
Add lang attribute to the CompileResult object

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ interface DescriptorCompileResult {
 
 interface CompileResult {
   code: string
+  lang?: string
   map?: any
 }
 

--- a/src/assembler.ts
+++ b/src/assembler.ts
@@ -7,7 +7,7 @@ import * as path from 'path'
 
 export interface AssembleSource {
   filename: string
-  script?: { source: string; map?: any }
+  script?: { source: string; map?: any, lang?: string }
   template?: { source: string; functional?: boolean }
   styles: Array<{
     source: string
@@ -221,14 +221,14 @@ export function assembleFromSource(
       var styleElement = document.createElement('style')
       styleElement.type = 'text/css'
       shadowRoot.appendChild(styleElement)
-    
+
       return styleElement
-    }    
+    }
 
     return function addStyle(id, css) {
       const styleElement = createStyleElement(shadowRoot)
       if (css.media) styleElement.setAttribute('media', css.media)
-      
+
       let code = css.source
 
       if (${e(compiler.template.isProduction)} && css.map) {
@@ -241,7 +241,7 @@ export function assembleFromSource(
           btoa(unescape(encodeURIComponent(JSON.stringify(css.map)))) +
           ' */'
       }
-      
+
       if ('styleSheet' in styleElement) {
         styleElement.styleSheet.cssText = code
       } else {
@@ -306,7 +306,7 @@ export function assembleFromSource(
         component._ssrRegister = hook
       }
       else if (style) {
-        hook = shadowMode 
+        hook = shadowMode
           ? function(context) {
               style.call(this, createInjectorShadow(context, this.$root.$options.shadowRoot))
             }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -47,6 +47,7 @@ export interface ScriptOptions {
 
 export interface CompileResult {
   code: string
+  lang?: string
   map?: any
 }
 export type StyleCompileResult = StyleCompileResults & {
@@ -113,7 +114,8 @@ export class SFCCompiler {
           code: rawScript.src
             ? this.read(rawScript.src, filename)
             : rawScript.content,
-          map: rawScript.map
+          map: rawScript.map,
+          lang: rawScript.lang
         }
       : undefined
 
@@ -159,7 +161,8 @@ export class SFCCompiler {
           code: rawScript.src
             ? this.read(rawScript.src, filename)
             : rawScript.content,
-          map: rawScript.map
+          map: rawScript.map,
+          lang: rawScript.lang
         }
       : undefined
 

--- a/test/__snapshots__/compile.spec.ts.snap
+++ b/test/__snapshots__/compile.spec.ts.snap
@@ -17,6 +17,7 @@ export default {
   }
 }
 ",
+    "lang": undefined,
     "map": Object {
       "file": "foo.vue",
       "mappings": ";;;;;;AAMA;AACA;AACA;AACA;AACA",
@@ -132,6 +133,7 @@ export default {
   }
 }
 ",
+    "lang": undefined,
     "map": Object {
       "file": "foo.vue",
       "mappings": ";;;;;;AAMA;AACA;AACA;AACA;AACA",

--- a/test/compile.spec.ts
+++ b/test/compile.spec.ts
@@ -61,6 +61,34 @@ function removeRawResult(result: DescriptorCompileResult): DescriptorCompileResu
   return result
 }
 
+
+test('detect script lang attribute', () => {
+  const source = `
+    <template>
+      <h1 id="test">Hello {{ name }}!</h1>
+    </template>
+
+    <script lang="ts">
+    export default {
+      data () {
+        return { name: 'John Doe' }
+      }
+    }
+    </script>
+
+    <style>
+    .title {
+      color: red;
+    }
+    </style>
+    `
+
+  const compiler = createDefaultCompiler()
+  const result = compiler.compileToDescriptor('foo.vue', source)
+
+  expect(result.script.lang).toBe('ts')
+})
+
 describe('when source contains css module', () => {
   const componentSource = `
     <template>

--- a/test/fixtures/with-langs.vue
+++ b/test/fixtures/with-langs.vue
@@ -2,12 +2,13 @@
   h1#test.title Hello {{ name }}!
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import Vue from 'vue'
+export default Vue.extend({
   data () {
     return { name: 'John Doe' }
   }
-}
+})
 </script>
 
 <style lang="scss">


### PR DESCRIPTION
This PR relates to https://github.com/vuejs/vue-component-compiler/issues/113 and adds an optional `lang` property to the `CompileResult` object to expose the language used in the SFC script tag. 